### PR TITLE
fix(docs): update broken internal links

### DIFF
--- a/src/content/docs/Guides/index.mdx
+++ b/src/content/docs/Guides/index.mdx
@@ -3,10 +3,10 @@ title: Guides
 ---
 Our Guides section offers in-depth tutorials and instructions on various features and best practices. Explore these guides to enhance your knowledge and make the most out of your documentation setup.
 
-- [Authoring Content in Markdown](./authoring-content-in-md.mdx): Learn how to author content using Markdown.
-- [Authoring Content in MDX](./authoring-content-in-mdx.mdx): Discover how to use MDX for more dynamic content.
-- [Breadcrumbs](./breadcrumbs.mdx): Understand how to implement breadcrumbs for better navigation.
-- [Pages](./pages.mdx): A guide on managing and creating pages in your documentation.
-- [Sidebar Navigation](./sidebar-navigation.mdx): Learn about configuring sidebar navigation for a better user experience.
-- [Site Search](./site-search.mdx): Instructions on adding search functionality to your site.
-- [Table of Contents](./table-of-contents.mdx): How to add and configure a Table of Contents for your documentation.
+- [Authoring Content in Markdown](./authoring-content-in-md): Learn how to author content using Markdown.
+- [Authoring Content in MDX](./authoring-content-in-mdx): Discover how to use MDX for more dynamic content.
+- [Breadcrumbs](./breadcrumbs): Understand how to implement breadcrumbs for better navigation.
+- [Pages](./pages): A guide on managing and creating pages in your documentation.
+- [Sidebar Navigation](./sidebar-navigation): Learn about configuring sidebar navigation for a better user experience.
+- [Site Search](./site-search): Instructions on adding search functionality to your site.
+- [Table of Contents](./table-of-contents): How to add and configure a Table of Contents for your documentation.


### PR DESCRIPTION
The links on the [guide page](https://celestialdocs.hyperoot.dev/guides/) are broken due to inclusion of the `.mdx` file extension in the markdown links.

Verified the links to work just by removing the mdx extensions in the URL bar, so this patch should fix it for good.