### PR TITLE
Remove pull request trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,6 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [closed]
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -16,8 +13,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Only run on merged PRs or direct pushes to main
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v6

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "celestialdocs",
     "type": "module",
     "version": "0.0.1",
+    "packageManager": "pnpm@9.12.3",
     "scripts": {
         "dev": "astro dev",
         "build": "astro build",


### PR DESCRIPTION
## Description
This update removes the pull request trigger from the CI workflow to streamline the deployment process. The change simplifies the conditions under which the workflow runs, focusing on direct pushes and manual triggers.

## Related Issue(s)
N/A

## What Changed
- Removed pull request trigger from the CI workflow.
- Simplified job conditions for workflow execution.
- Added `packageManager` field to the package configuration.

## Testing
- Environment: Node.js 20.11.1, pnpm 9.12.3, macOS 14
- Manual tests performed: Verified that the CI workflow executes correctly on pushes and manual dispatches.
- Accessibility checks performed: N/A

## Checklist
- [ ] Followed project coding standards (Astro + Tailwind guidelines)
- [ ] Added/updated component or API documentation if needed
- [ ] Verified UI renders correctly across major browsers/devices
- [ ] Verified accessibility (alt text, labels, focus states, contrast)
- [ ] No console warnings or build errors
- [ ] PR title follows Conventional Commits

## Additional Notes
This change may affect how pull requests are handled in the CI process, so review the implications for team workflows.

